### PR TITLE
Prevent line wrapping on “ASCII Mandelbrot Set”

### DIFF
--- a/articles/2020-05-05-mandel.md
+++ b/articles/2020-05-05-mandel.md
@@ -23,6 +23,7 @@ Feel free to poke around [on GitHub](https://github.com/jdan/thatjdanisso.cool/b
 <style>
   #mandel {
     line-height: 1;
+    white-space: nowrap;
   }
 
   @media (max-width: 480px) {


### PR DESCRIPTION
Turns this:

<img width="692" alt="Screen Shot 2021-07-06 at 3 46 42 PM" src="https://user-images.githubusercontent.com/1840854/124658744-ff800380-de58-11eb-9566-a7eeeebf45ef.png">

💫 into this: 💫

<img width="597" alt="Screen Shot 2021-07-06 at 3 56 07 PM" src="https://user-images.githubusercontent.com/1840854/124659209-8e8d1b80-de59-11eb-8a99-3d8dceb953b1.png">